### PR TITLE
feat: add local Qwen ASR transcription option

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -12,14 +12,16 @@ import (
 )
 
 var transcribeOpts struct {
-	provider     string
-	endpoint     string
-	model        string
-	apiKey       string
-	language     string
-	systemPrompt string
-	jsonOutput   bool
-	timeout      time.Duration
+	provider           string
+	endpoint           string
+	model              string
+	apiKey             string
+	language           string
+	systemPrompt       string
+	responseFormat     string
+	speakerDiarization bool
+	jsonOutput         bool
+	timeout            time.Duration
 }
 
 var transcribeCmd = &cobra.Command{
@@ -49,11 +51,13 @@ Then run:
 		}
 
 		result, err := asr.TranscribeQwen(ctx, args[0], asr.QwenOptions{
-			Endpoint:     transcribeOpts.endpoint,
-			APIKey:       transcribeOpts.apiKey,
-			Model:        transcribeOpts.model,
-			Language:     transcribeOpts.language,
-			SystemPrompt: transcribeOpts.systemPrompt,
+			Endpoint:                 transcribeOpts.endpoint,
+			APIKey:                   transcribeOpts.apiKey,
+			Model:                    transcribeOpts.model,
+			Language:                 transcribeOpts.language,
+			SystemPrompt:             transcribeOpts.systemPrompt,
+			ResponseFormat:           transcribeOpts.responseFormat,
+			EnableSpeakerDiarization: transcribeOpts.speakerDiarization,
 		})
 		if err != nil {
 			return err
@@ -77,6 +81,8 @@ func init() {
 	transcribeCmd.Flags().StringVar(&transcribeOpts.apiKey, "api-key", "", "optional bearer token for a protected local endpoint")
 	transcribeCmd.Flags().StringVar(&transcribeOpts.language, "language", "", "optional source language hint, for example English or Chinese")
 	transcribeCmd.Flags().StringVar(&transcribeOpts.systemPrompt, "system-prompt", "", "optional context text to bias recognition")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.responseFormat, "response-format", asr.DefaultQwenResponseFormat, "Qwen response format: json, text, verbose_json, srt, or vtt")
+	transcribeCmd.Flags().BoolVar(&transcribeOpts.speakerDiarization, "speaker-diarization", false, "enable speaker diarization; slower on CPU Qwen servers")
 	transcribeCmd.Flags().BoolVar(&transcribeOpts.jsonOutput, "json", false, "print full transcript metadata as JSON")
 	transcribeCmd.Flags().DurationVar(&transcribeOpts.timeout, "timeout", 5*time.Minute, "request timeout")
 }

--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mnemon-dev/mnemon/internal/asr"
+	"github.com/spf13/cobra"
+)
+
+var transcribeOpts struct {
+	provider     string
+	endpoint     string
+	model        string
+	apiKey       string
+	language     string
+	systemPrompt string
+	jsonOutput   bool
+	timeout      time.Duration
+}
+
+var transcribeCmd = &cobra.Command{
+	Use:   "transcribe <audio-file-or-url>",
+	Short: "Transcribe audio with locally hosted Qwen ASR",
+	Long: `Transcribe a local audio file or public audio URL with a locally hosted
+Qwen ASR OpenAI-compatible server.
+
+Start a local server first, for example:
+
+  docker run -p 17003:8000 quantatrisk/qwen3-asr:cpu-latest
+
+Then run:
+
+  mnemon transcribe ./voice-note.mp3`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if transcribeOpts.provider != "qwen" {
+			return fmt.Errorf("unsupported ASR provider %q (supported: qwen)", transcribeOpts.provider)
+		}
+
+		ctx := cmd.Context()
+		if transcribeOpts.timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, transcribeOpts.timeout)
+			defer cancel()
+		}
+
+		result, err := asr.TranscribeQwen(ctx, args[0], asr.QwenOptions{
+			Endpoint:     transcribeOpts.endpoint,
+			APIKey:       transcribeOpts.apiKey,
+			Model:        transcribeOpts.model,
+			Language:     transcribeOpts.language,
+			SystemPrompt: transcribeOpts.systemPrompt,
+		})
+		if err != nil {
+			return err
+		}
+
+		if transcribeOpts.jsonOutput {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
+		}
+		fmt.Fprintln(os.Stdout, result.Text)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(transcribeCmd)
+	transcribeCmd.Flags().StringVar(&transcribeOpts.provider, "provider", "qwen", "ASR provider")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.endpoint, "endpoint", asr.DefaultQwenEndpoint, "local Qwen ASR OpenAI-compatible transcription endpoint")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.model, "model", asr.DefaultQwenModel, "Qwen ASR model")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.apiKey, "api-key", "", "optional bearer token for a protected local endpoint")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.language, "language", "", "optional source language hint, for example English or Chinese")
+	transcribeCmd.Flags().StringVar(&transcribeOpts.systemPrompt, "system-prompt", "", "optional context text to bias recognition")
+	transcribeCmd.Flags().BoolVar(&transcribeOpts.jsonOutput, "json", false, "print full transcript metadata as JSON")
+	transcribeCmd.Flags().DurationVar(&transcribeOpts.timeout, "timeout", 5*time.Minute, "request timeout")
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -157,6 +157,42 @@ mnemon log              # operation log (default: last 20)
 mnemon log --limit 50   # show more entries
 ```
 
+### Audio Transcription
+
+Transcribe a local audio file or public audio URL with a locally hosted Qwen ASR server. This keeps the privacy/offline posture of local Whisper workflows while making Qwen available as an alternative ASR backend.
+
+Start a local Qwen ASR server:
+
+```bash
+docker run -p 17003:8000 quantatrisk/qwen3-asr:cpu-latest
+```
+
+Then transcribe:
+
+```bash
+mnemon transcribe ./voice-note.mp3
+mnemon transcribe https://example.com/audio.wav --language English
+mnemon transcribe ./meeting.mp3 --json --system-prompt "Names: Mnemon, OpenClaw"
+```
+
+NanoClaw/container deployment can run Qwen ASR as a sidecar service and point Mnemon at it:
+
+```bash
+mnemon transcribe ./voice-note.mp3 --endpoint http://qwen-asr:8000/v1/audio/transcriptions
+```
+
+Defaults:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--provider` | `qwen` | ASR provider |
+| `--endpoint` | `http://localhost:17003/v1/audio/transcriptions` | Local Qwen ASR OpenAI-compatible transcription endpoint |
+| `--model` | `qwen3-asr-0.6b` | Qwen ASR model |
+| `--api-key` | *(empty)* | Optional bearer token for a protected local endpoint |
+| `--language` | *(auto)* | Optional language hint, such as `English` or `Chinese` |
+| `--system-prompt` | *(empty)* | Context text to bias recognition with names/domain terms |
+| `--json` | `false` | Include metadata such as detected language, model, and seconds |
+
 ### Visualization
 
 Export the knowledge graph for visual exploration:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -159,7 +159,7 @@ mnemon log --limit 50   # show more entries
 
 ### Audio Transcription
 
-Transcribe a local audio file or public audio URL with a locally hosted Qwen ASR server. This keeps the privacy/offline posture of local Whisper workflows while making Qwen available as an alternative ASR backend.
+Transcribe a local audio file or public audio URL with a locally hosted Qwen ASR server. Upstream Mnemon operates on text memories; this command adds an optional local audio-to-text ingestion step without introducing a hosted transcription dependency.
 
 Start a local Qwen ASR server:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -173,6 +173,7 @@ Then transcribe:
 mnemon transcribe ./voice-note.mp3
 mnemon transcribe https://example.com/audio.wav --language English
 mnemon transcribe ./meeting.mp3 --json --system-prompt "Names: Mnemon, OpenClaw"
+mnemon transcribe ./meeting.mp3 --response-format verbose_json --speaker-diarization
 ```
 
 NanoClaw/container deployment can run Qwen ASR as a sidecar service and point Mnemon at it:
@@ -191,7 +192,12 @@ Defaults:
 | `--api-key` | *(empty)* | Optional bearer token for a protected local endpoint |
 | `--language` | *(auto)* | Optional language hint, such as `English` or `Chinese` |
 | `--system-prompt` | *(empty)* | Context text to bias recognition with names/domain terms |
+| `--response-format` | `json` | Qwen response format sent to the server. Use `verbose_json` only when segment metadata is needed |
+| `--speaker-diarization` | `false` | Enable speaker diarization. This is slower on CPU Qwen servers |
 | `--json` | `false` | Include metadata such as detected language, model, and seconds |
+| `--timeout` | `5m` | Request timeout. CPU Qwen servers can run much slower than realtime |
+
+Mnemon defaults to the lightweight Qwen request path: `response_format=json` and `enable_speaker_diarization=false`. This avoids forcing segment/speaker metadata for ordinary transcript extraction, which is especially important on CPU-only Qwen deployments.
 
 ### Visualization
 

--- a/internal/asr/qwen.go
+++ b/internal/asr/qwen.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -21,18 +22,21 @@ const (
 	// DefaultQwenEndpoint targets a locally running Qwen3-ASR server that exposes
 	// the OpenAI-compatible audio transcriptions endpoint.
 	// Example: docker run -p 17003:8000 quantatrisk/qwen3-asr:cpu-latest
-	DefaultQwenEndpoint = "http://localhost:17003/v1/audio/transcriptions"
-	DefaultQwenModel    = "qwen3-asr-0.6b"
+	DefaultQwenEndpoint       = "http://localhost:17003/v1/audio/transcriptions"
+	DefaultQwenModel          = "qwen3-asr-0.6b"
+	DefaultQwenResponseFormat = "json"
 )
 
 // QwenOptions configures a local Qwen ASR transcription request.
 type QwenOptions struct {
-	Endpoint     string
-	APIKey       string
-	Model        string
-	Language     string
-	SystemPrompt string
-	HTTPClient   *http.Client
+	Endpoint                 string
+	APIKey                   string
+	Model                    string
+	Language                 string
+	SystemPrompt             string
+	ResponseFormat           string
+	EnableSpeakerDiarization bool
+	HTTPClient               *http.Client
 }
 
 // Transcript is the normalized result returned by an ASR provider.
@@ -44,11 +48,11 @@ type Transcript struct {
 }
 
 type qwenTranscriptionResponse struct {
-	Text     string `json:"text"`
-	Language string `json:"language,omitempty"`
-	Model    string `json:"model,omitempty"`
+	Text     string  `json:"text"`
+	Language string  `json:"language,omitempty"`
+	Model    string  `json:"model,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
-	Seconds  int    `json:"seconds,omitempty"`
+	Seconds  int     `json:"seconds,omitempty"`
 	Error    *struct {
 		Message string `json:"message"`
 		Code    string `json:"code"`
@@ -66,6 +70,9 @@ func TranscribeQwen(ctx context.Context, input string, opts QwenOptions) (Transc
 	}
 	if opts.Model == "" {
 		opts.Model = DefaultQwenModel
+	}
+	if opts.ResponseFormat == "" {
+		opts.ResponseFormat = DefaultQwenResponseFormat
 	}
 	client := opts.HTTPClient
 	if client == nil {
@@ -139,7 +146,14 @@ func buildTranscriptionRequest(input string, opts QwenOptions) (io.Reader, strin
 	if err := writer.WriteField("model", opts.Model); err != nil {
 		return nil, "", err
 	}
-	if err := writer.WriteField("response_format", "verbose_json"); err != nil {
+	responseFormat := strings.TrimSpace(opts.ResponseFormat)
+	if responseFormat == "" {
+		responseFormat = DefaultQwenResponseFormat
+	}
+	if err := writer.WriteField("response_format", responseFormat); err != nil {
+		return nil, "", err
+	}
+	if err := writer.WriteField("enable_speaker_diarization", strconv.FormatBool(opts.EnableSpeakerDiarization)); err != nil {
 		return nil, "", err
 	}
 	if strings.TrimSpace(opts.Language) != "" {

--- a/internal/asr/qwen.go
+++ b/internal/asr/qwen.go
@@ -1,0 +1,184 @@
+package asr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultQwenEndpoint targets a locally running Qwen3-ASR server that exposes
+	// the OpenAI-compatible audio transcriptions endpoint.
+	// Example: docker run -p 17003:8000 quantatrisk/qwen3-asr:cpu-latest
+	DefaultQwenEndpoint = "http://localhost:17003/v1/audio/transcriptions"
+	DefaultQwenModel    = "qwen3-asr-0.6b"
+)
+
+// QwenOptions configures a local Qwen ASR transcription request.
+type QwenOptions struct {
+	Endpoint     string
+	APIKey       string
+	Model        string
+	Language     string
+	SystemPrompt string
+	HTTPClient   *http.Client
+}
+
+// Transcript is the normalized result returned by an ASR provider.
+type Transcript struct {
+	Text     string `json:"text"`
+	Language string `json:"language,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Seconds  int    `json:"seconds,omitempty"`
+}
+
+type qwenTranscriptionResponse struct {
+	Text     string `json:"text"`
+	Language string `json:"language,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Duration int    `json:"duration,omitempty"`
+	Seconds  int    `json:"seconds,omitempty"`
+	Error    *struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	} `json:"error,omitempty"`
+}
+
+// TranscribeQwen transcribes a local audio file or public audio URL with a
+// locally hosted Qwen ASR OpenAI-compatible server.
+func TranscribeQwen(ctx context.Context, input string, opts QwenOptions) (Transcript, error) {
+	if strings.TrimSpace(input) == "" {
+		return Transcript{}, errors.New("audio input is required")
+	}
+	if opts.Endpoint == "" {
+		opts.Endpoint = DefaultQwenEndpoint
+	}
+	if opts.Model == "" {
+		opts.Model = DefaultQwenModel
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+
+	body, contentType, err := buildTranscriptionRequest(input, opts)
+	if err != nil {
+		return Transcript{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, opts.Endpoint, body)
+	if err != nil {
+		return Transcript{}, err
+	}
+	if opts.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Transcript{}, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Transcript{}, fmt.Errorf("read qwen response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var decoded qwenTranscriptionResponse
+		if json.Unmarshal(respBody, &decoded) == nil && decoded.Error != nil && decoded.Error.Message != "" {
+			return Transcript{}, fmt.Errorf("qwen asr failed (%s): %s", resp.Status, decoded.Error.Message)
+		}
+		return Transcript{}, fmt.Errorf("qwen asr failed: %s", resp.Status)
+	}
+
+	contentType = strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "text/plain") {
+		return Transcript{Text: strings.TrimSpace(string(respBody)), Model: opts.Model}, nil
+	}
+
+	var decoded qwenTranscriptionResponse
+	if err := json.Unmarshal(respBody, &decoded); err != nil {
+		return Transcript{}, fmt.Errorf("decode qwen response: %w", err)
+	}
+	if decoded.Text == "" {
+		return Transcript{}, errors.New("qwen asr response did not contain transcript text")
+	}
+	seconds := decoded.Seconds
+	if seconds == 0 {
+		seconds = decoded.Duration
+	}
+	model := decoded.Model
+	if model == "" {
+		model = opts.Model
+	}
+	return Transcript{
+		Text:     decoded.Text,
+		Language: decoded.Language,
+		Model:    model,
+		Seconds:  seconds,
+	}, nil
+}
+
+func buildTranscriptionRequest(input string, opts QwenOptions) (io.Reader, string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	if err := writer.WriteField("model", opts.Model); err != nil {
+		return nil, "", err
+	}
+	if err := writer.WriteField("response_format", "verbose_json"); err != nil {
+		return nil, "", err
+	}
+	if strings.TrimSpace(opts.Language) != "" {
+		if err := writer.WriteField("language", strings.TrimSpace(opts.Language)); err != nil {
+			return nil, "", err
+		}
+	}
+	if strings.TrimSpace(opts.SystemPrompt) != "" {
+		if err := writer.WriteField("prompt", strings.TrimSpace(opts.SystemPrompt)); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if isRemoteURL(input) {
+		if err := writer.WriteField("audio_address", input); err != nil {
+			return nil, "", err
+		}
+	} else {
+		file, err := os.Open(input)
+		if err != nil {
+			return nil, "", fmt.Errorf("open audio file: %w", err)
+		}
+		defer file.Close()
+
+		part, err := writer.CreateFormFile("file", filepath.Base(input))
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := io.Copy(part, file); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return &body, writer.FormDataContentType(), nil
+}
+
+func isRemoteURL(input string) bool {
+	parsed, err := url.Parse(input)
+	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https")
+}

--- a/internal/asr/qwen.go
+++ b/internal/asr/qwen.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -46,7 +47,7 @@ type qwenTranscriptionResponse struct {
 	Text     string `json:"text"`
 	Language string `json:"language,omitempty"`
 	Model    string `json:"model,omitempty"`
-	Duration int    `json:"duration,omitempty"`
+	Duration float64 `json:"duration,omitempty"`
 	Seconds  int    `json:"seconds,omitempty"`
 	Error    *struct {
 		Message string `json:"message"`
@@ -116,8 +117,8 @@ func TranscribeQwen(ctx context.Context, input string, opts QwenOptions) (Transc
 		return Transcript{}, errors.New("qwen asr response did not contain transcript text")
 	}
 	seconds := decoded.Seconds
-	if seconds == 0 {
-		seconds = decoded.Duration
+	if seconds == 0 && decoded.Duration > 0 {
+		seconds = int(math.Ceil(decoded.Duration))
 	}
 	model := decoded.Model
 	if model == "" {

--- a/internal/asr/qwen_test.go
+++ b/internal/asr/qwen_test.go
@@ -1,0 +1,117 @@
+package asr
+
+import (
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTranscribeQwenLocalFile(t *testing.T) {
+	path := t.TempDir() + "/sample.mp3"
+	if err := os.WriteFile(path, []byte("fake-audio"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer local-token" {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+			t.Fatalf("Content-Type = %q", r.Header.Get("Content-Type"))
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		if got := r.FormValue("model"); got != DefaultQwenModel {
+			t.Fatalf("model = %q", got)
+		}
+		if got := r.FormValue("language"); got != "en" {
+			t.Fatalf("language = %q", got)
+		}
+		if got := r.FormValue("prompt"); got != "names: Mnemon" {
+			t.Fatalf("prompt = %q", got)
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile: %v", err)
+		}
+		defer file.Close()
+		if header.Filename != "sample.mp3" {
+			t.Fatalf("filename = %q", header.Filename)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(qwenTranscriptionResponse{
+			Text:     "hello mnemon",
+			Language: "en",
+			Model:    DefaultQwenModel,
+			Seconds:  3,
+		})
+	}))
+	defer server.Close()
+
+	got, err := TranscribeQwen(context.Background(), path, QwenOptions{
+		Endpoint:     server.URL,
+		APIKey:       "local-token",
+		Language:     "en",
+		SystemPrompt: "names: Mnemon",
+	})
+	if err != nil {
+		t.Fatalf("TranscribeQwen error: %v", err)
+	}
+	if got.Text != "hello mnemon" || got.Language != "en" || got.Seconds != 3 {
+		t.Fatalf("unexpected transcript: %#v", got)
+	}
+}
+
+func TestTranscribeQwenRemoteURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		if got := r.FormValue("audio_address"); got != "https://example.com/audio.mp3" {
+			t.Fatalf("audio_address = %q", got)
+		}
+		if _, _, err := r.FormFile("file"); err != http.ErrMissingFile {
+			t.Fatalf("expected no file upload, got err=%v", err)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("remote transcript"))
+	}))
+	defer server.Close()
+
+	got, err := TranscribeQwen(context.Background(), "https://example.com/audio.mp3", QwenOptions{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("TranscribeQwen error: %v", err)
+	}
+	if got.Text != "remote transcript" {
+		t.Fatalf("unexpected transcript: %#v", got)
+	}
+}
+
+func TestBuildTranscriptionRequest(t *testing.T) {
+	path := t.TempDir() + "/sample.wav"
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body, contentType, err := buildTranscriptionRequest(path, QwenOptions{Model: "qwen3-asr-0.6b"})
+	if err != nil {
+		t.Fatalf("buildTranscriptionRequest error: %v", err)
+	}
+	reader := multipart.NewReader(body, strings.TrimPrefix(contentType, "multipart/form-data; boundary="))
+	form, err := reader.ReadForm(1 << 20)
+	if err != nil {
+		t.Fatalf("ReadForm: %v", err)
+	}
+	if got := form.Value["model"][0]; got != "qwen3-asr-0.6b" {
+		t.Fatalf("model = %q", got)
+	}
+	if len(form.File["file"]) != 1 {
+		t.Fatalf("file count = %d", len(form.File["file"]))
+	}
+}

--- a/internal/asr/qwen_test.go
+++ b/internal/asr/qwen_test.go
@@ -50,7 +50,7 @@ func TestTranscribeQwenLocalFile(t *testing.T) {
 			Text:     "hello mnemon",
 			Language: "en",
 			Model:    DefaultQwenModel,
-			Seconds:  3,
+			Duration: 2.4,
 		})
 	}))
 	defer server.Close()

--- a/internal/asr/qwen_test.go
+++ b/internal/asr/qwen_test.go
@@ -30,6 +30,12 @@ func TestTranscribeQwenLocalFile(t *testing.T) {
 		if got := r.FormValue("model"); got != DefaultQwenModel {
 			t.Fatalf("model = %q", got)
 		}
+		if got := r.FormValue("response_format"); got != DefaultQwenResponseFormat {
+			t.Fatalf("response_format = %q", got)
+		}
+		if got := r.FormValue("enable_speaker_diarization"); got != "false" {
+			t.Fatalf("enable_speaker_diarization = %q", got)
+		}
 		if got := r.FormValue("language"); got != "en" {
 			t.Fatalf("language = %q", got)
 		}
@@ -111,7 +117,39 @@ func TestBuildTranscriptionRequest(t *testing.T) {
 	if got := form.Value["model"][0]; got != "qwen3-asr-0.6b" {
 		t.Fatalf("model = %q", got)
 	}
+	if got := form.Value["response_format"][0]; got != DefaultQwenResponseFormat {
+		t.Fatalf("response_format = %q", got)
+	}
+	if got := form.Value["enable_speaker_diarization"][0]; got != "false" {
+		t.Fatalf("enable_speaker_diarization = %q", got)
+	}
 	if len(form.File["file"]) != 1 {
 		t.Fatalf("file count = %d", len(form.File["file"]))
+	}
+}
+
+func TestBuildTranscriptionRequestAllowsVerboseDiarization(t *testing.T) {
+	path := t.TempDir() + "/sample.wav"
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body, contentType, err := buildTranscriptionRequest(path, QwenOptions{
+		Model:                    "qwen3-asr-0.6b",
+		ResponseFormat:           "verbose_json",
+		EnableSpeakerDiarization: true,
+	})
+	if err != nil {
+		t.Fatalf("buildTranscriptionRequest error: %v", err)
+	}
+	reader := multipart.NewReader(body, strings.TrimPrefix(contentType, "multipart/form-data; boundary="))
+	form, err := reader.ReadForm(1 << 20)
+	if err != nil {
+		t.Fatalf("ReadForm: %v", err)
+	}
+	if got := form.Value["response_format"][0]; got != "verbose_json" {
+		t.Fatalf("response_format = %q", got)
+	}
+	if got := form.Value["enable_speaker_diarization"][0]; got != "true" {
+		t.Fatalf("enable_speaker_diarization = %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Adds Qwen ASR as an optional **locally hosted** transcription path via a new `mnemon transcribe` command.

Upstream Mnemon currently operates on text memories. This PR adds an optional local audio-to-text ingestion step via Qwen ASR; it is not replacing an existing Mnemon transcriber. The default endpoint is a local OpenAI-compatible audio transcription server: `http://localhost:17003/v1/audio/transcriptions`.

## Why add local Qwen ASR

- **Audio-to-memory bridge**: lets callers turn audio files or public audio URLs into text before storing/using them with Mnemon.
- **Privacy/offline posture**: keeps audio on the user's own machine/container network instead of requiring a hosted transcription service.
- **Better multilingual/code-switching target**: Qwen3-ASR is designed for multilingual recognition across many languages and Chinese dialects, useful for real voice notes that mix English, Chinese, acronyms, names, and local terms.
- **Domain/entity biasing**: `--system-prompt` maps to the transcription prompt field, so callers can provide names, acronyms, project terms, and domain vocabulary for better memory ingestion.
- **CPU fallback exists**: the documented `quantatrisk/qwen3-asr:cpu-latest` path runs the Qwen3-ASR 0.6B CPU/Rust backend for machines without NVIDIA GPUs.
- **Container/NanoClaw friendly**: a NanoClaw-style deployment can run Qwen ASR as a sidecar and point Mnemon at `http://qwen-asr:8000/v1/audio/transcriptions`.
- **Provider-agnostic integration surface**: uses an OpenAI-compatible `/v1/audio/transcriptions` endpoint, so the ASR server can be swapped without changing Mnemon's CLI.

## Local usage

```bash
docker run -p 17003:8000 quantatrisk/qwen3-asr:cpu-latest

mnemon transcribe ./voice-note.mp3
mnemon transcribe ./meeting.mp3 --json --system-prompt "Names: Mnemon, OpenClaw"
mnemon transcribe ./meeting.mp3 --response-format verbose_json --speaker-diarization
```

For container/NanoClaw-style setups:

```bash
mnemon transcribe ./voice-note.mp3 --endpoint http://qwen-asr:8000/v1/audio/transcriptions
```

## What changed

- Adds `internal/asr` with local Qwen ASR OpenAI-compatible `/v1/audio/transcriptions` handling.
- Adds `mnemon transcribe <audio-file-or-url>`.
- Supports local audio file upload and remote URLs via `audio_address`.
- Defaults Qwen requests to the lightweight path: `response_format=json` and `enable_speaker_diarization=false`.
- Keeps heavier segment/speaker metadata opt-in with `--response-format verbose_json --speaker-diarization`.
- Adds flags:
  - `--endpoint`
  - `--model`
  - `--api-key` for protected local endpoints
  - `--language`
  - `--system-prompt`
  - `--response-format`
  - `--speaker-diarization`
  - `--json`
  - `--timeout`
- Documents local Qwen ASR and NanoClaw/sidecar usage.

## CPU timeout note

The CPU container is functional but slow. On the local CPU host, the default Qwen server behavior of `verbose_json` plus speaker diarization caused a short 5.86s LibriSpeech sample to take about 86-87s server-side, so a 60s client timeout was too short.

This PR now avoids that heavier path by default. Verbose JSON and speaker diarization remain available when the caller explicitly needs them.

## Verification

- `go test ./...`
- `go build ./...`
- CLI tested against a mock local OpenAI-compatible transcription server.
- Local Qwen endpoint check: `/v1/models` returned `qwen3-asr-0.6b`.
- Live local CPU container check completed through Mnemon's default lightweight path and returned:

```json
{
  "text": "Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.",
  "model": "qwen3-asr-0.6b"
}
```
